### PR TITLE
Add action to create our own WPT archive

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -1,0 +1,30 @@
+name: Release WPT
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit or branch name to fetch'
+        default: master
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout WPT
+        uses: actions/checkout@v4
+        with:
+          repository: 'web-platform-tests/wpt'
+          ref: ${{ inputs.ref }}
+      - name: Create Github Release
+        shell: bash
+        run: |
+          RELEASE_NAME=wpt-$(git rev-parse --short HEAD)
+          gh release create -R ${{ github.repository }} $RELEASE_NAME || true
+          git archive --prefix=$RELEASE_NAME/ -o $RELEASE_NAME.tar.gz HEAD '*.js' '*.json' '*.md'
+          gh release upload -R ${{ github.repository }} $RELEASE_NAME $RELEASE_NAME.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}


### PR DESCRIPTION
We use Web Platform Tests to test workerd. Currently, we depend on the Github-provided tarballs for the WPT release we use. However, these downloads don't seem to be stable, with the hash changing from time to time. This is a nuisance for anyone trying to roll deps.

In this PR, I've added a small action to download WPT, pack it into an archive and upload it as a fixed asset to a Github release. This way we know the generation of the archive is entirely under our control. This should put a stop to this nuisance.