### PR TITLE
Build WPT package weekly

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -1,6 +1,9 @@
 name: Release WPT
 
 on:
+  schedule:
+    # Runs at 00:15, only on Sunday.
+    - cron: "15 00 * * 0" 
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
This is the really easy part of our idea to update WPT automatically. 

Unfortunately, we'll need to go into this repo and either make a useless commit or re-enable the workflow every 60 days. Thanks, Github.

> In a public repository, scheduled workflows are automatically disabled when no repository activity has occurred in 60 days. For information on re-enabling a disabled workflow, see Disabling and enabling a workflow.