### PR TITLE
Don't fail-fast the LLVM build matrix

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -31,6 +31,7 @@ jobs:
   build:
     needs: create-release
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - os: darwin-arm64


### PR DESCRIPTION
When one platform's build in the LLVM build matrix fails the strategy currently cancels the other in-progress jobs, discarding the ~45 minutes of work each had done. Set `fail-fast: false` so the surviving platforms continue to completion and upload their assets.

This came up because the `windows-amd64` clang-tidy build currently fails on `windows-latest`: the runner now ships MinGW GCC 15.2.0, whose libstdc++ no longer transitively pulls `<cstdint>` into `<initializer_list>`, and LLVM 18.1.8's `SmallVector.h` uses `uint32_t`/`uint64_t` without an explicit include. That made the prior `clang-tidy-18.1.8` dispatch cancel the darwin and linux builds we actually wanted. With this change those three would have completed and uploaded their binaries + `clang-tidy-dev` header tarballs.

The Windows failure is real and visible — the workflow run still shows red, the Windows job still shows red. The proper fix is bumping our LLVM pin (later versions already include the missing `#include <cstdint>` upstream); this PR just stops the windows breakage from also taking down the healthy platforms.